### PR TITLE
#63 정보글 불러오는 방식 수정

### DIFF
--- a/src/main/resources/static/src/js/fetchTitles.js
+++ b/src/main/resources/static/src/js/fetchTitles.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", function () {
+
     // 정보 게시판의 뉴스 제목을 로드
     const infoList = document.querySelector('.board-content-info');
 
@@ -7,6 +8,25 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // 제목을 <li> 요소로 변환하여 삽입
     infoList.innerHTML = newsItems.map(item => `<li><a href="${item.url}" target="_blank">${item.title}</a></li>`).join('');
+    /*
+    // 웹서버에 데이터 요청하는 방식으로 수정
+    const infoList = document.querySelector('.board-content-info');
+
+    fetch('/infolist')
+        .then(response => response.json())
+        .then(data => {
+            data.forEach(infodata => {
+                const row = document.createElement('li');
+                row.innerHTML = `<li><a href="${infodata.url}" target="_blank">${infodata.title}</a></li>`;
+                infoList.appendChild();
+            })
+        })
+        .catch(error => {
+            console.error('정보글 불러오기 오류:', error);
+            boardContent.innerHTML = '<li>정보글 정보를 불러올 수 없습니다.</li>';
+        });
+    */
+
 });
 
 document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
- 홈 화면에서 정보글을 불러올 때 로컬 스토리지를 활용한 방식으로 구현되어 있어, 처음 웹페이지에 접속하는 사용자는 해당 정보가 뜨지 않는 문제가 있음
- 따라서 정보글 데이터를 DB에 저장하고 웹서버에 요청하는 방식으로 수정하고자 fetchTitles.js 코드를 수정하고 일단 에러가 나지 않도록 주석 처리해 둠